### PR TITLE
fix#4 use url_prefix while registering blueprint instead of setting s…

### DIFF
--- a/flask_fontawesome/__init__.py
+++ b/flask_fontawesome/__init__.py
@@ -120,8 +120,8 @@ class FontAwesome(object):
         blueprint = Blueprint(
             'fontawesome',
             __name__,
-            static_folder='static',
-            static_url_path=app.static_url_path + '/fontawesome')
+            static_folder='static')
+            #static_url_path=app.static_url_path + '/fontawesome')
 
         static = StaticCdn()
         use_fa = UseFontAwesomeComCdn()
@@ -133,4 +133,4 @@ class FontAwesome(object):
                 return use_fa.resources_html()
 
         app.jinja_env.globals['fontawesome_html'] = fontawesome_html
-        app.register_blueprint(blueprint)
+        app.register_blueprint(blueprint, url_prefix='/fontawesome')

--- a/flask_fontawesome/__init__.py
+++ b/flask_fontawesome/__init__.py
@@ -106,7 +106,7 @@ class UseFontAwesomeComCdn(Cdn):
 
 class FontAwesome(object):
 
-    def __init__(self, app: Flask=None) -> None:
+    def __init__(self, app: Flask = None) -> None:
         if app is not None:
             self.init_app(app)
 
@@ -121,7 +121,6 @@ class FontAwesome(object):
             'fontawesome',
             __name__,
             static_folder='static')
-            #static_url_path=app.static_url_path + '/fontawesome')
 
         static = StaticCdn()
         use_fa = UseFontAwesomeComCdn()


### PR DESCRIPTION
use url_prefix while registering blueprint instead of setting static_url_path
I have tested this modification on a Debian strech with success (no more error while getting fontawesome.min.css)